### PR TITLE
Adding missing requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 _ncaa_courses_cache
+*.csv
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+BeautifulSoup==3.2.1
+cssselect==1.0.0
+lxml==3.6.4
+requests==2.12.3
+six==1.10.0


### PR DESCRIPTION
The [installation](https://github.com/newsapps/ncaa-high-school-course-scraper#installation) instructions in README.md include `pip install -r requirements.txt`, but that file is missing from the repo. This pull request adds it with (I think) all the correct dependencies/versions.

Also includes ignoring any .csv files output by the scraper and the OSX `.DS_Store` system files.